### PR TITLE
[TASK] Add EEL IndexingHelper method to get properties from an array of nodes

### DIFF
--- a/Classes/TYPO3/TYPO3CR/Search/Eel/IndexingHelper.php
+++ b/Classes/TYPO3/TYPO3CR/Search/Eel/IndexingHelper.php
@@ -103,6 +103,25 @@ class IndexingHelper implements ProtectedContextAwareInterface {
 	}
 
 	/**
+	 * Convert an array of nodes to an array of node property
+	 *
+	 * @param array<NodeInterface> $nodes
+	 * @param string $propertyName
+	 * @return array
+	 */
+	public function convertArrayOfNodesToArrayOfNodeProperty($nodes, $propertyName) {
+		if (!is_array($nodes) && !$nodes instanceof \Traversable) {
+			return array();
+		}
+		$nodeProperties = array();
+		foreach ($nodes as $node) {
+			$nodeProperties[] = $node->getProperty($propertyName);
+		}
+
+		return $nodeProperties;
+	}
+
+	/**
 	 *
 	 * @param $string
 	 * @return array


### PR DESCRIPTION
This change add a new method IndexingHelper::convertArrayOfNodesToArrayOfNodeProperty
to extract the given property from an array of nodes.