### PR TITLE
[BUGFIX] Use different bootstrap step for indexing slot registration

### DIFF
--- a/Classes/TYPO3/TYPO3CR/Search/Package.php
+++ b/Classes/TYPO3/TYPO3CR/Search/Package.php
@@ -31,7 +31,7 @@ class Package extends BasePackage {
 		$dispatcher = $bootstrap->getSignalSlotDispatcher();
 		$package = $this;
 		$dispatcher->connect('TYPO3\Flow\Core\Booting\Sequence', 'afterInvokeStep', function(Step $step) use ($package, $bootstrap) {
-			if ($step->getIdentifier() === 'typo3.flow:persistence') {
+			if ($step->getIdentifier() === 'typo3.flow:reflectionservice') {
 				$package->registerIndexingSlots($bootstrap);
 			}
 		});


### PR DESCRIPTION
With the defered initialization of the PersistenceManager (https://github.com/neos/flow/commit/7cd305e51e2d791b4be51587629ce524d3fe0a38) the bootstrap step "typo3.flow:persistence" is not called any more. Thus, real time indexing did not work as it relied on this bootstrap step.
As a workaround, this commit changes the step to "typo3.flow:reflectionservice" (which was called right before the persistence step before).