### PR TITLE
TASK: Introduce BulkNodeIndexerInterface

### DIFF
--- a/Classes/TYPO3/TYPO3CR/Search/Indexer/BulkNodeIndexerInterface.php
+++ b/Classes/TYPO3/TYPO3CR/Search/Indexer/BulkNodeIndexerInterface.php
@@ -1,0 +1,34 @@
+<?php
+namespace TYPO3\TYPO3CR\Search\Indexer;
+
+/*                                                                              *
+ * This script belongs to the TYPO3 Flow package "TYPO3.TYPO3CR.Search".        *
+ *                                                                              *
+ * It is free software; you can redistribute it and/or modify it under          *
+ * the terms of the GNU General Public License, either version 3                *
+ *  of the License, or (at your option) any later version.                      *
+ *                                                                              *
+ * The TYPO3 project - inspiring people to share!                               *
+ *                                                                              */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+
+
+/**
+ * Indexer for Content Repository Nodes with bulk mode support
+ *
+ */
+interface BulkNodeIndexerInterface {
+
+	/**
+	 * Perform indexing without checking about duplication document
+	 *
+	 * This is used during bulk indexing to improve performance
+	 *
+	 * @param callable $callback
+	 * @return void
+	 */
+	public function withBulkProcessing(callable $callback);
+
+}


### PR DESCRIPTION
This change add a new interface for the node indexers. This is useful when
the search service support bulk indexing, so features of the indexer can be
tuned to improve performance.