### PR TITLE
TASK: Add the root path to the parent prefixes

### DIFF
--- a/Classes/TYPO3/TYPO3CR/Search/Eel/IndexingHelper.php
+++ b/Classes/TYPO3/TYPO3CR/Search/Eel/IndexingHelper.php
@@ -25,15 +25,17 @@ class IndexingHelper implements ProtectedContextAwareInterface
     /**
      * Build all path prefixes. From an input such as:
      *
-     *   foo/bar/baz
+     *   /foo/bar/baz
      *
      * it emits an array with:
      *
-     *   foo
-     *   foo/bar
-     *   foo/bar/baz
+     *   /
+     *   /foo
+     *   /foo/bar
+     *   /foo/bar/baz
      *
-     * This method works both with absolute and relative paths.
+     * This method works both with absolute and relative paths. If a relative path is given,
+     * the returned array will lack the first element and the leading slashes, obviously.
      *
      * @param string $path
      * @return array<string>

--- a/Classes/TYPO3/TYPO3CR/Search/Eel/IndexingHelper.php
+++ b/Classes/TYPO3/TYPO3CR/Search/Eel/IndexingHelper.php
@@ -47,12 +47,13 @@ class IndexingHelper implements ProtectedContextAwareInterface
         }
 
         $currentPath = '';
+        $pathPrefixes = [];
         if ($path{0} === '/') {
             $currentPath = '/';
+            $pathPrefixes[] = $currentPath;
         }
         $path = ltrim($path, '/');
 
-        $pathPrefixes = [];
         foreach (explode('/', $path) as $pathPart) {
             $currentPath .= $pathPart . '/';
             $pathPrefixes[] = rtrim($currentPath, '/');

--- a/Tests/Unit/Eel/IndexingHelperTest.php
+++ b/Tests/Unit/Eel/IndexingHelperTest.php
@@ -51,6 +51,7 @@ class IndexingHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         $input = '/foo/bar/baz/testing';
         $expected = array(
+            '/',
             '/foo',
             '/foo/bar',
             '/foo/bar/baz',


### PR DESCRIPTION
When an absolute path is given to `buildAllPathPrefixes()`, the returned array
will now contain '/' as the first entry. This makes sure all indexed nodes can
actually be found, when a search is restricted to '/' as the base path.