### PR TITLE
BUGFIX: Realtime indexing signals registration

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -37,7 +37,7 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
         $package = $this;
         $dispatcher->connect(Sequence::class, 'afterInvokeStep', function (Step $step) use ($package, $bootstrap) {
-            if ($step->getIdentifier() === 'neos.flow:reflectionservice') {
+            if ($step->getIdentifier() === 'neos.flow:objectmanagement:runtime') {
                 $package->registerIndexingSlots($bootstrap);
             }
         });


### PR DESCRIPTION
With Neos 4.1 the realtime indexing isn't working anymore due to the signals being registered too late in the process resulting in the `NodeIndexingManager` never getting called. Using a different invocation step solves the issue.