### PR TITLE
[BUGFIX] Remove void returntypes as they don't work with PHP 7.0 and …

### DIFF
--- a/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -73,7 +73,7 @@ class PaginateController extends AbstractWidgetController
     /**
      * @return void
      */
-    protected function initializeAction() : void
+    protected function initializeAction()
     {
         $this->query = $this->widgetConfiguration['query'];
         $this->configuration = Arrays::arrayMergeRecursiveOverrule(
@@ -90,7 +90,7 @@ class PaginateController extends AbstractWidgetController
      * @param int $currentPage
      * @return void
      */
-    public function indexAction($currentPage = 1) : void
+    public function indexAction($currentPage = 1)
     {
         $this->currentPage = (int)$currentPage;
         if ($this->currentPage < 1) {


### PR DESCRIPTION
…that version is not required in composer.json

Resolves https://github.com/neos/typo3cr-search/issues/32