### PR TITLE
BUGFIX: Fix version constraints for flow version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_install:
   - cd ..
   - git clone https://github.com/neos/neos-development-distribution.git -b master
   - cd neos-development-distribution
-  - composer require neos/content-repository-search dev-master
+  - composer require --no-update --no-interaction neos/content-repository-search dev-master
 install:
-  - composer install
+  - COMPOSER_MEMORY_LIMIT=-1 composer install
   - cd ..
   - rm -rf neos-development-distribution/Packages/Application/Neos.ContentRepository.Search
   - mv typo3cr-search neos-development-distribution/Packages/Application/Neos.ContentRepository.Search

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
+    - php: 7.2
       env: DB=mysql
-    - php: 7.0
+      addons:
+        mariadb: '10.2'
+    - php: 7.2
       env: DB=pgsql
       sudo: true
       dist: trusty

--- a/Classes/Eel/IndexingHelper.php
+++ b/Classes/Eel/IndexingHelper.php
@@ -50,7 +50,7 @@ class IndexingHelper implements ProtectedContextAwareInterface
 
         $currentPath = '';
         $pathPrefixes = [];
-        if ($path{0} === '/') {
+        if (strpos($path, '/') === 0) {
             $currentPath = '/';
             $pathPrefixes[] = $currentPath;
         }

--- a/Classes/Indexer/AbstractNodeIndexer.php
+++ b/Classes/Indexer/AbstractNodeIndexer.php
@@ -11,9 +11,11 @@ namespace Neos\ContentRepository\Search\Indexer;
  * source code.
  */
 
+use Neos\ContentRepository\Exception\NodeException;
 use Neos\Eel\Utility as EelUtility;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Search\Exception\IndexingException;
@@ -52,6 +54,7 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * Called by the Flow object framework after creating the object and resolving all dependencies.
      *
      * @param integer $cause Creation cause
+     * @throws InvalidConfigurationTypeException
      */
     public function initializeObject($cause)
     {
@@ -91,6 +94,8 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @param string $fulltextExtractionExpression
      * @param array $fulltextIndexOfNode
      * @throws IndexingException
+     * @throws NodeException
+     * @throws \Neos\Eel\Exception
      */
     protected function extractFulltext(NodeInterface $node, $propertyName, $fulltextExtractionExpression, array &$fulltextIndexOfNode)
     {
@@ -118,6 +123,9 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @param array $fulltextData
      * @param \Closure $nonIndexedPropertyErrorHandler
      * @return array
+     * @throws IndexingException
+     * @throws NodeException
+     * @throws \Neos\Eel\Exception
      */
     protected function extractPropertiesAndFulltext(NodeInterface $node, array &$fulltextData, \Closure $nonIndexedPropertyErrorHandler = null)
     {

--- a/Classes/Indexer/AbstractNodeIndexer.php
+++ b/Classes/Indexer/AbstractNodeIndexer.php
@@ -11,11 +11,9 @@ namespace Neos\ContentRepository\Search\Indexer;
  * source code.
  */
 
-use Neos\ContentRepository\Exception\NodeException;
 use Neos\Eel\Utility as EelUtility;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
-use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Search\Exception\IndexingException;
@@ -54,7 +52,6 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * Called by the Flow object framework after creating the object and resolving all dependencies.
      *
      * @param integer $cause Creation cause
-     * @throws InvalidConfigurationTypeException
      */
     public function initializeObject($cause)
     {
@@ -94,8 +91,6 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @param string $fulltextExtractionExpression
      * @param array $fulltextIndexOfNode
      * @throws IndexingException
-     * @throws NodeException
-     * @throws \Neos\Eel\Exception
      */
     protected function extractFulltext(NodeInterface $node, $propertyName, $fulltextExtractionExpression, array &$fulltextIndexOfNode)
     {
@@ -123,9 +118,6 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @param array $fulltextData
      * @param \Closure $nonIndexedPropertyErrorHandler
      * @return array
-     * @throws IndexingException
-     * @throws NodeException
-     * @throws \Neos\Eel\Exception
      */
     protected function extractPropertiesAndFulltext(NodeInterface $node, array &$fulltextData, \Closure $nonIndexedPropertyErrorHandler = null)
     {

--- a/Classes/Indexer/AbstractNodeIndexer.php
+++ b/Classes/Indexer/AbstractNodeIndexer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\ContentRepository\Search\Indexer;
 
 /*
@@ -96,7 +97,7 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @throws \Neos\ContentRepository\Exception\NodeException
      * @throws \Neos\Eel\Exception
      */
-    protected function extractFulltext(NodeInterface $node, $propertyName, $fulltextExtractionExpression, array &$fulltextIndexOfNode)
+    protected function extractFulltext(NodeInterface $node, $propertyName, $fulltextExtractionExpression, array &$fulltextIndexOfNode): void
     {
         if ($fulltextExtractionExpression !== '') {
             $extractedFulltext = $this->evaluateEelExpression($fulltextExtractionExpression, $node, $propertyName, ($node->hasProperty($propertyName) ? $node->getProperty($propertyName) : null));
@@ -109,7 +110,11 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
                 if (!isset($fulltextIndexOfNode[$bucket])) {
                     $fulltextIndexOfNode[$bucket] = '';
                 }
-                $fulltextIndexOfNode[$bucket] .= ' ' . $value;
+
+                $value = trim($value);
+                if ($value !== '') {
+                    $fulltextIndexOfNode[$bucket] .= ' ' . $value;
+                }
             }
         }
         // TODO: also allow fulltextExtractor in settings!!

--- a/Classes/Indexer/AbstractNodeIndexer.php
+++ b/Classes/Indexer/AbstractNodeIndexer.php
@@ -14,6 +14,7 @@ namespace Neos\ContentRepository\Search\Indexer;
 use Neos\Eel\Utility as EelUtility;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Search\Exception\IndexingException;
@@ -52,6 +53,7 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * Called by the Flow object framework after creating the object and resolving all dependencies.
      *
      * @param integer $cause Creation cause
+     * @throws InvalidConfigurationTypeException
      */
     public function initializeObject($cause)
     {
@@ -91,6 +93,8 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @param string $fulltextExtractionExpression
      * @param array $fulltextIndexOfNode
      * @throws IndexingException
+     * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws \Neos\Eel\Exception
      */
     protected function extractFulltext(NodeInterface $node, $propertyName, $fulltextExtractionExpression, array &$fulltextIndexOfNode)
     {
@@ -118,6 +122,9 @@ abstract class AbstractNodeIndexer implements NodeIndexerInterface
      * @param array $fulltextData
      * @param \Closure $nonIndexedPropertyErrorHandler
      * @return array
+     * @throws IndexingException
+     * @throws \Neos\ContentRepository\Exception\NodeException
+     * @throws \Neos\Eel\Exception
      */
     protected function extractPropertiesAndFulltext(NodeInterface $node, array &$fulltextData, \Closure $nonIndexedPropertyErrorHandler = null)
     {

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -37,7 +37,7 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
         $package = $this;
         $dispatcher->connect(Sequence::class, 'afterInvokeStep', function (Step $step) use ($package, $bootstrap) {
-            if ($step->getIdentifier() === 'neos.flow:reflectionservice') {
+            if ($step->getIdentifier() === 'neos.flow:objectmanagement:runtime') {
                 $package->registerIndexingSlots($bootstrap);
             }
         });

--- a/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -73,7 +73,7 @@ class PaginateController extends AbstractWidgetController
     /**
      * @return void
      */
-    protected function initializeAction() : void
+    protected function initializeAction()
     {
         $this->query = $this->widgetConfiguration['query'];
         $this->configuration = Arrays::arrayMergeRecursiveOverrule(
@@ -90,7 +90,7 @@ class PaginateController extends AbstractWidgetController
      * @param int $currentPage
      * @return void
      */
-    public function indexAction($currentPage = 1) : void
+    public function indexAction($currentPage = 1)
     {
         $this->currentPage = (int)$currentPage;
         if ($this->currentPage < 1) {

--- a/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -11,8 +11,9 @@ namespace Neos\ContentRepository\Search\ViewHelpers\Widget\Controller;
  * source code.
  */
 
-use Neos\Utility\Arrays;
+use Neos\ContentRepository\Search\Search\QueryBuilderInterface;
 use Neos\FluidAdaptor\Core\Widget\AbstractWidgetController;
+use Neos\Utility\Arrays;
 
 /**
  * Controller for the paginate widget
@@ -20,14 +21,19 @@ use Neos\FluidAdaptor\Core\Widget\AbstractWidgetController;
 class PaginateController extends AbstractWidgetController
 {
     /**
-     * @var \Neos\ContentRepository\Search\Search\QueryBuilderInterface
+     * @var QueryBuilderInterface
      */
     protected $query;
 
     /**
      * @var array
      */
-    protected $configuration = array('itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99);
+    protected $configuration = [
+        'insertAbove' => false,
+        'insertBelow' => true,
+        'itemsPerPage' => 10,
+        'maximumNumberOfLinks' => 99,
+    ];
 
     /**
      * @var integer
@@ -67,37 +73,40 @@ class PaginateController extends AbstractWidgetController
     /**
      * @return void
      */
-    protected function initializeAction()
+    protected function initializeAction() : void
     {
         $this->query = $this->widgetConfiguration['query'];
-        $this->configuration = Arrays::arrayMergeRecursiveOverrule($this->configuration, $this->widgetConfiguration['configuration'], true);
-        $this->numberOfPages = (integer)ceil($this->query->count() / (integer)$this->configuration['itemsPerPage']);
-        $this->maximumNumberOfLinks = (integer)$this->configuration['maximumNumberOfLinks'];
+        $this->configuration = Arrays::arrayMergeRecursiveOverrule(
+            $this->configuration,
+            $this->widgetConfiguration['configuration'],
+            true
+        );
+
+        $this->numberOfPages = (int)ceil($this->query->count() / (int)$this->configuration['itemsPerPage']);
+        $this->maximumNumberOfLinks = (int)$this->configuration['maximumNumberOfLinks'];
     }
 
     /**
-     * @param integer $currentPage
+     * @param int $currentPage
      * @return void
      */
-    public function indexAction($currentPage = 1)
+    public function indexAction($currentPage = 1) : void
     {
-        $this->currentPage = (integer)$currentPage;
+        $this->currentPage = (int)$currentPage;
         if ($this->currentPage < 1) {
             $this->currentPage = 1;
         } elseif ($this->currentPage > $this->numberOfPages) {
             $this->currentPage = $this->numberOfPages;
         }
 
-        $itemsPerPage = (integer)$this->configuration['itemsPerPage'];
+        $itemsPerPage = (int)$this->configuration['itemsPerPage'];
         $this->query->limit($itemsPerPage);
         if ($this->currentPage > 1) {
-            $this->query->from((integer)($itemsPerPage * ($this->currentPage - 1)));
+            $this->query->from($itemsPerPage * ($this->currentPage - 1));
         }
         $modifiedObjects = $this->query->execute();
 
-        $this->view->assign('contentArguments', array(
-            $this->widgetConfiguration['as'] => $modifiedObjects
-        ));
+        $this->view->assign('contentArguments', [$this->widgetConfiguration['as'] => $modifiedObjects]);
         $this->view->assign('configuration', $this->configuration);
         $this->view->assign('pagination', $this->buildPagination());
     }
@@ -135,11 +144,11 @@ class PaginateController extends AbstractWidgetController
     protected function buildPagination()
     {
         $this->calculateDisplayRange();
-        $pages = array();
+        $pages = [];
         for ($i = $this->displayRangeStart; $i <= $this->displayRangeEnd; $i++) {
-            $pages[] = array('number' => $i, 'isCurrent' => ($i === $this->currentPage));
+            $pages[] = ['number' => $i, 'isCurrent' => ($i === $this->currentPage)];
         }
-        $pagination = array(
+        $pagination = [
             'pages' => $pages,
             'current' => $this->currentPage,
             'numberOfPages' => $this->numberOfPages,
@@ -147,7 +156,7 @@ class PaginateController extends AbstractWidgetController
             'displayRangeEnd' => $this->displayRangeEnd,
             'hasLessPages' => $this->displayRangeStart > 2,
             'hasMorePages' => $this->displayRangeEnd + 1 < $this->numberOfPages
-        );
+        ];
         if ($this->currentPage < $this->numberOfPages) {
             $pagination['nextPage'] = $this->currentPage + 1;
         }

--- a/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -11,9 +11,14 @@ namespace Neos\ContentRepository\Search\ViewHelpers\Widget;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
-use Neos\FluidAdaptor\Core\Widget\AbstractWidgetViewHelper;
 use Neos\ContentRepository\Search\Search\QueryBuilderInterface;
+use Neos\ContentRepository\Search\ViewHelpers\Widget\Controller\PaginateController;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Exception\InfiniteLoopException;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
+use Neos\FluidAdaptor\Core\Widget\AbstractWidgetViewHelper;
+use Neos\FluidAdaptor\Core\Widget\Exception\InvalidControllerException;
+use Neos\FluidAdaptor\Core\Widget\Exception\MissingControllerException;
 
 /**
  * This ViewHelper renders a Pagination of search results.
@@ -24,21 +29,41 @@ class PaginateViewHelper extends AbstractWidgetViewHelper
 {
     /**
      * @Flow\Inject
-     * @var \Neos\ContentRepository\Search\ViewHelpers\Widget\Controller\PaginateController
+     * @var PaginateController
      */
     protected $controller;
 
     /**
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws ViewHelperException
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+
+        $this->registerArgument('query', QueryBuilderInterface::class, 'Query', true);
+        $this->registerArgument('as', 'string', 'as', true);
+        $this->registerArgument(
+            'configuration',
+            'array',
+            'Widget configuration',
+            false,
+            ['insertAbove' => false, 'insertBelow' => true, 'itemsPerPage' => 10, 'maximumNumberOfLinks' => 99]
+        );
+    }
+
+    /**
      * Render this view helper
      *
-     * @param QueryBuilderInterface $query
-     * @param string $as
-     * @param array $configuration
      * @return string
+     * @throws InfiniteLoopException
+     * @throws InvalidControllerException
+     * @throws MissingControllerException
      */
-    public function render(QueryBuilderInterface $query, $as, array $configuration = array('itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99))
+    public function render() : string
     {
-        $response = $this->initiateSubRequest();
-        return $response->getContent();
+        return $this->initiateSubRequest();
     }
 }

--- a/Tests/Functional/Eel/ElasticSearchHelperTest.php
+++ b/Tests/Functional/Eel/ElasticSearchHelperTest.php
@@ -24,7 +24,7 @@ class ElasticSearchHelperTest extends \Neos\Flow\Tests\FunctionalTestCase
      */
     protected $helper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = new IndexingHelper();
         parent::setUp();
@@ -47,6 +47,6 @@ class ElasticSearchHelperTest extends \Neos\Flow\Tests\FunctionalTestCase
         );
 
         $actual = $this->helper->extractNodeTypeNamesAndSupertypes($nodeType);
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/Tests/Unit/Eel/IndexingHelperTest.php
+++ b/Tests/Unit/Eel/IndexingHelperTest.php
@@ -23,7 +23,7 @@ class IndexingHelperTest extends \Neos\Flow\Tests\UnitTestCase
      */
     protected $helper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = new IndexingHelper();
     }
@@ -41,7 +41,7 @@ class IndexingHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'foo/bar/baz/testing',
         );
 
-        $this->assertSame($expected, $this->helper->buildAllPathPrefixes($input));
+        self::assertSame($expected, $this->helper->buildAllPathPrefixes($input));
     }
 
     /**
@@ -58,7 +58,7 @@ class IndexingHelperTest extends \Neos\Flow\Tests\UnitTestCase
             '/foo/bar/baz/testing',
         );
 
-        $this->assertSame($expected, $this->helper->buildAllPathPrefixes($input));
+        self::assertSame($expected, $this->helper->buildAllPathPrefixes($input));
     }
 
     /**
@@ -71,7 +71,7 @@ class IndexingHelperTest extends \Neos\Flow\Tests\UnitTestCase
             '/'
         );
 
-        $this->assertSame($expected, $this->helper->buildAllPathPrefixes($input));
+        self::assertSame($expected, $this->helper->buildAllPathPrefixes($input));
     }
 
     /**
@@ -85,6 +85,6 @@ class IndexingHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'h2' => ' How do you feel? I Feel so good '
         );
 
-        $this->assertSame($expected, $this->helper->extractHtmlTags($input));
+        self::assertSame($expected, $this->helper->extractHtmlTags($input));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "neos-package",
     "description": "Common code and interface for a Neos CR search implementation",
     "require": {
-        "neos/flow": "^4.0 || ^5.0 || ^6.0",
-        "neos/content-repository": "^3.0 || ^4.0 || ^5.0"
+        "neos/flow": "^4.0 || ^5.0",
+        "neos/content-repository": "^3.0 || ^4.0"
     },
     "replace": {
         "typo3/typo3cr-search": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "neos-package",
     "description": "Common code and interface for a Neos CR search implementation",
     "require": {
-        "neos/flow": "^4.0 || ^5.0 || dev-master",
-        "neos/content-repository": "^3.0 || ^4.0 || dev-master"
+        "neos/flow": "^4.0 || ^5.0 || ^6.0",
+        "neos/content-repository": "^3.0 || ^4.0 || ^6.0"
     },
     "replace": {
         "typo3/typo3cr-search": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Common code and interface for a Neos CR search implementation",
     "require": {
         "neos/flow": "^4.0 || ^5.0 || ^6.0",
-        "neos/content-repository": "^3.0 || ^4.0 || ^6.0"
+        "neos/content-repository": "^3.0 || ^4.0 || ^5.0"
     },
     "replace": {
         "typo3/typo3cr-search": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "neos-package",
     "description": "Common code and interface for a Neos CR search implementation",
     "require": {
-        "neos/flow": "^4.0 || dev-master",
-        "neos/content-repository": "^3.0 || dev-master"
+        "neos/flow": "^4.0 || ^5.0 || dev-master",
+        "neos/content-repository": "^3.0 || ^4.0 || dev-master"
     },
     "replace": {
         "typo3/typo3cr-search": "self.version"


### PR DESCRIPTION
The latest version 3.0.8 changed the version constraints, so that the package version was not available anymore for the flow 5.x users. The versions before were available and as the version 3.0.8 makes the package PHP 7.4 compatible the users of Neos 4.3 and flow 5.3 wants to use the version, of course.

This change just brings back the compatibility for flow 5. With higher versions, the package is not compatible as the interfaces for the QueryBuilder for instance changed, and the constraint was more a result of a mistake.

Resolves: #45
